### PR TITLE
[WIP] feature add examples 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,12 @@ name = "rufka"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+name = "rust_kafka_like"
+path = "src/lib.rs"
+
+[[example]]
+name = "send-recv-example"
+path = "examples/send-recv-example.rs"
+
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ MIT
 
 - main.rs: Main implementation
 - logs: Persistent Message Directory
+
+### Examples
+
+To execute a basic example, use the following command:
+
+```bash
+cargo run --example send-recv-example
+```

--- a/examples/send-recv-example.rs
+++ b/examples/send-recv-example.rs
@@ -1,0 +1,68 @@
+extern crate rust_kafka_like as rufka;   
+use std::error::Error;
+use std::collections::{HashMap, HashSet};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+    mpsc::{Receiver, Sender, channel},
+};
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut peers = HashSet::new();
+    peers.insert("broker2".to_string());
+    peers.insert("broker3".to_string());
+    
+    println!("Initializing broker...");
+    let broker = Arc::new(Mutex::new(rufka::Broker::new(
+        "broker1".to_string(),
+        "logs",
+        3,
+        peers,
+        2,
+    ).expect("Failed to create Broker"),
+));
+
+    if let Ok(mut broker_ref) = broker.lock() {
+        println!("Creating a topic...");
+        broker_ref.create_topic("test_topic", Some(3))?;
+
+        println!("Registering a subscriber...");
+        broker_ref.subscribe(
+            "test_topic",
+            Box::new(|message, ack_sender| {
+                println!("Received message: {}", message);
+                ack_sender
+                    .send(rufka::MessageAck {
+                        message_id: 0, // TODO: Set an appropriate ID
+                        topic: "test_topic".to_string(),
+                        status: rufka::AckStatus::Success,
+                    })
+                    .unwrap();
+            }),
+        )?;
+
+        broker_ref.start_health_check();
+    }
+
+    let broker_producer = Arc::clone(&broker);
+    let producer_handle = thread::spawn(move || {
+        println!("I started as a producer....");
+        thread::sleep(Duration::from_secs(2));
+
+        if let Ok(broker) = broker_producer.lock() {
+            println!("Sending message...");
+            match broker.publish_with_ack("test_topic", "Test message".to_string(), None) {
+                Ok(ack) => println!("Received message confirmation response: {:?}", ack),
+                Err(e) => eprintln!("Message publication error: {}", e),
+            }
+        }
+    });
+
+    thread::sleep(Duration::from_secs(3));
+    producer_handle.join().unwrap();
+
+    println!("Quit the program");
+    Ok(())
+}


### PR DESCRIPTION
### What?

This PR serves as a starting point for better managing the example code currently located in `main.rs`. I reorganized the code from `rust-kafka-like/src/main.rs `by converting it into a library. Following the [Rust Book's guidelines](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#examples), I moved the sample code into the rust-kafka-like/examples folder.

### Why?

This structure improves code organization by separating the general library code from the specific example implementation.

### How?

I updated the `Cargo.toml` file to declare `src/lib.rs` as the library file and `examples/send-recv-example.rs` as the example code file. During the refactor, I made some structures and functions public so they could be accessed by the example file.

If keeping these structures and functions private is preferred as a design choice, please let me know. If so, kindly suggest a suitable pattern, and I’ll adjust the code accordingly.

### Testing?

I ran the sample code using the command:

`cargo run --example send-recv-example`

Everything worked as expected.

I’m not an expert and created this PR as a learning opportunity. Please @mila411 , provide feedback on my work. Thank you!