### PR TITLE
fix: implement automatic node recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "pilgrimage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilgrimage"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Kenny Miller Song"]
 description = "A Kafka-like message broker in Rust"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-    <a href="https://tip.golang.org/doc/go1.19">
-      <img src="https://img.shields.io/badge/Rust-1.51-007ACC.svg?logo=Rust">
+    <a href="https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html">
+      <img src="https://img.shields.io/badge/Rust-1.83-007ACC.svg?logo=Rust">
     </a>
 </p>
 

--- a/test_db_path
+++ b/test_db_path
@@ -1,0 +1,1 @@
+Initialized


### PR DESCRIPTION
## Fault detection:

The monitor_nodes method is used to periodically check the health of the nodes.
The is_available method is used to check the status of the storage.

## Automatic recovery:

The recover_node method is used to reinitialize the storage and reset the assignment of consumer groups as necessary.
The recover_node method is called when a fault is detected within the monitor_nodes method.