### PR TITLE
Exclude GitHub Actions bot from build and test jobs; update dependencies and benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +41,7 @@ jobs:
         run: cargo build
 
   test:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     needs: build
 
@@ -64,6 +66,9 @@ jobs:
           for example in $(ls examples); do
             cargo run --example $(basename $example .rs);
           done
+
+      - name: Run bench
+        run: cargo bench
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -856,9 +856,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,98 +1,40 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use pilgrimage::broker::{Broker, Node};
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 fn broker_benchmark(c: &mut Criterion) {
+    // Brokerの初期化
+    let broker = Broker::new("broker1", 3, 2, "storage_path");
+
+    // ノードの追加
+    let node1 = Node {
+        data: Arc::new(Mutex::new(Vec::new())),
+    };
+    let node2 = Node {
+        data: Arc::new(Mutex::new(Vec::new())),
+    };
+    broker.add_node("node1".to_string(), node1);
+    broker.add_node("node2".to_string(), node2);
+
     let mut group = c.benchmark_group("broker_benchmarks");
 
     group.bench_function("start_election", |b| {
         b.iter(|| {
-            let broker = Broker::new("broker1", 3, 2, "storage_path");
-            let node1 = Node {
-                data: Arc::new(Mutex::new(Vec::new())),
-            };
-            let node2 = Node {
-                data: Arc::new(Mutex::new(Vec::new())),
-            };
-            broker.add_node("node1".to_string(), node1);
-            broker.add_node("node2".to_string(), node2);
-            broker.start_election();
+            black_box(broker.start_election());
         })
     });
 
     group.bench_function("send_message", |b| {
         b.iter(|| {
-            let broker = Broker::new("broker1", 3, 2, "storage_path");
-            broker.send_message("test message".to_string());
+            black_box(broker.send_message("test message".to_string()));
         })
     });
 
     group.bench_function("receive_message", |b| {
         b.iter(|| {
-            let broker = Broker::new("broker1", 3, 2, "storage_path");
-            broker.send_message("test message".to_string());
-            broker.receive_message();
-        })
-    });
-
-    group.bench_function("process_messages", |b| {
-        b.iter(|| {
-            let broker = Broker::new("broker1", 3, 2, "storage_path");
-            for i in 0..100 {
-                broker.send_message(format!("message {}", i));
-            }
-            for _ in 0..100 {
-                broker.receive_message();
-            }
-        })
-    });
-
-    group.bench_function("send_message_multithreaded", |b| {
-        b.iter(|| {
-            let broker = Arc::new(Broker::new("broker1", 3, 2, "storage_path"));
-
-            let broker_sender = Arc::clone(&broker);
-            let sender_handle = thread::spawn(move || {
-                for i in 0..10 {
-                    let message = format!("Message {}", i);
-                    broker_sender.send_message(message);
-                }
-            });
-
-            let broker_receiver = Arc::clone(&broker);
-            let receiver_handle = thread::spawn(move || {
-                for _ in 0..10 {
-                    if let Some(_message) = broker_receiver.receive_message() {}
-                }
-            });
-
-            sender_handle.join().unwrap();
-            receiver_handle.join().unwrap();
-        })
-    });
-
-    group.bench_function("process_messages_multithreaded", |b| {
-        b.iter(|| {
-            let broker = Arc::new(Broker::new("broker1", 3, 2, "storage_path"));
-
-            let broker_sender = Arc::clone(&broker);
-            let sender_handle = thread::spawn(move || {
-                for i in 0..100 {
-                    let message = format!("message {}", i);
-                    broker_sender.send_message(message);
-                }
-            });
-
-            let broker_receiver = Arc::clone(&broker);
-            let receiver_handle = thread::spawn(move || {
-                for _ in 0..100 {
-                    if let Some(_message) = broker_receiver.receive_message() {}
-                }
-            });
-
-            sender_handle.join().unwrap();
-            receiver_handle.join().unwrap();
+            // 受信前にメッセージを送信
+            broker.send_message("benchmark message".to_string());
+            black_box(broker.receive_message());
         })
     });
 

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -20,7 +20,7 @@ use crate::broker::topic::Topic;
 use crate::message::ack::MessageAck;
 use crate::subscriber::types::Subscriber;
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -470,6 +470,7 @@ pub struct Partition {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::fs::OpenOptions;
     use std::fs::{self, File};
     use std::path::Path;
     use std::sync::{Arc, Condvar, Mutex};


### PR DESCRIPTION
Exclude the GitHub Actions bot from triggering build and test jobs. Update several dependencies to their latest versions and refine benchmark tests for improved performance.