### PR TITLE
fix: Update CI workflow to add all changes and allow dirty publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,7 +143,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Commit changes
-          git add Cargo.toml Cargo.lock
+          git add .
           git commit -m "Bump version to $NEW_VERSION" || echo "No changes to commit"
 
           # Create a tag
@@ -169,4 +169,4 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
+        run: cargo publish --allow-dirty

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-/// Trigger for CI testing line
+// Trigger for CI testing line
 pub mod auth;
 pub mod broker;
 pub mod crypto;


### PR DESCRIPTION
Enhance the CI workflow to include all changes in the commit and allow publishing with uncommitted modifications. Adjust a comment for clarity.