### PR TITLE
fix: Update CI workflow to commit specific files and bump version to 0.8.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,12 +138,15 @@ jobs:
           # Update the version of Cargo.toml
           sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
 
+          # Update Cargo.lock
+          cargo check
+
           # Git settings
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Commit changes
-          git add .
+          git add Cargo.toml Cargo.lock
           git commit -m "Bump version to $NEW_VERSION" || echo "No changes to commit"
 
           # Create a tag
@@ -169,4 +172,5 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --allow-dirty
+        run: cargo publish
+        # run: cargo publish --allow-dirty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "pilgrimage"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "aes-gcm",
  "criterion",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Trigger for CI testing line
+/// Trigger for CI testing line
 pub mod auth;
 pub mod broker;
 pub mod crypto;


### PR DESCRIPTION
Revise the CI workflow to commit specific files and update the version in Cargo.toml and Cargo.lock. Adjust the documentation comment for clarity.