### PR TITLE
fix(cli): author name

### DIFF
--- a/src/bin/pilgrimage.rs
+++ b/src/bin/pilgrimage.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 fn main() {
     let matches = App::new("Pilgrimage")
         .version("1.0")
-        .author("Your Name")
+        .author("Kenny (Miller) Song")
         .about("Message Broker CLI")
         .subcommand(
             SubCommand::with_name("start")


### PR DESCRIPTION
The author name was "Your Name", fix it with the correct name.

I don't made an issue because is a one line fix; however i notice it during the documentation.